### PR TITLE
Support for Tailwind opacity using var() and fix for SCSS compilers incompatibility

### DIFF
--- a/src/lib/rgb-functional-notation.js
+++ b/src/lib/rgb-functional-notation.js
@@ -16,7 +16,7 @@ function legacyChannel(value) {
 function getColorData(colorFn) {
     /* const rgbSyntaxRegex = /(\w{3})a?\s*\((\d*\.?\d+\%?)\s+(\d*\.?\d+\%?)
     \s+(\d*\.?\d+\%?)(?:\s*\/\s*(\d*\.?\d+\%?))?\)/g; */
-    const rgbSyntaxPlusAltRegex = /(rgb)a?\s*\(\s*(\d*\.?\d+\%?)(?:\s+|(?:\s*,\s*))(\d*\.?\d+\%?)(?:\s+|(?:\s*,\s*))(\d*\.?\d+\%?)(?:\s*(?:\/|,)\s*(\d*\.?\d+\%?))?\s*\)/g; // eslint-disable-line max-len
+    const rgbSyntaxPlusAltRegex = /(rgb)a?\s*\(\s*(\d*\.?\d+\%?)(?:\s+|(?:\s*,\s*))(\d*\.?\d+\%?)(?:\s+|(?:\s*,\s*))(\d*\.?\d+\%?)(?:\s*(?:\/?|,)\s*(\d*\.?\d+\%?))?\s*\)/g; // eslint-disable-line max-len
     const match = rgbSyntaxPlusAltRegex.exec(colorFn);
     if (match === null) return false;
     return {

--- a/src/lib/rgb-functional-notation.js
+++ b/src/lib/rgb-functional-notation.js
@@ -16,7 +16,7 @@ function legacyChannel(value) {
 function getColorData(colorFn) {
     /* const rgbSyntaxRegex = /(\w{3})a?\s*\((\d*\.?\d+\%?)\s+(\d*\.?\d+\%?)
     \s+(\d*\.?\d+\%?)(?:\s*\/\s*(\d*\.?\d+\%?))?\)/g; */
-    const rgbSyntaxPlusAltRegex = /(rgb)a?\s*\(\s*(\d*\.?\d+\%?)(?:\s+|(?:\s*,\s*))(\d*\.?\d+\%?)(?:\s+|(?:\s*,\s*))(\d*\.?\d+\%?)(?:\s*(?:\/?|,)\s*(\d*\.?\d+\%?))?\s*\)/g; // eslint-disable-line max-len
+    const rgbSyntaxPlusAltRegex = /(rgb)a?\s*\(\s*(\d*\.?\d+\%?)(?:\s+|(?:\s*,\s*))(\d*\.?\d+\%?)(?:\s+|(?:\s*,\s*))(\d*\.?\d+\%?)(?:\s*(?:\/?|,)\s*(var\([a-z-0-9,\s]+\)||\d*\.?\d+\%?))?\s*\)/g; // eslint-disable-line max-len
     const match = rgbSyntaxPlusAltRegex.exec(colorFn);
     if (match === null) return false;
     return {


### PR DESCRIPTION
This pull request improves 2 things:

1. Add support for Tailwind 3 rgb opacity using CSS var() ie.

```
color: rgb(186 230 253 / var(--tw-text-opacity));
```

2. Some SCSS/SASS compilers don't like the new syntax for rgb stripping out `/` making the code incompatible with browsers ie.

```
color: rgb(186 230 253 / var(--tw-text-opacity));
```

becomes

```
color: rgb(186 230 253 var(--tw-text-opacity));
```

The updated code makes the `/` optional, so if the compiler strips it out, the postcss-color-rgb plugin will still process it.

All of the below cases are now supported:

```
rgb(255 0 0 / var(--tw-text-opacity))
rgb(255 0 0 var(--tw-text-opacity))
rgb(255 0 0 / 0.5)
rgb(255 0 0 0.5)
```